### PR TITLE
jump immediatly on return

### DIFF
--- a/ace-pinyin.el
+++ b/ace-pinyin.el
@@ -490,7 +490,8 @@ If ARG is non-nil, read input from Minibuffer."
     ;; Read input by using timer
     (message "Query word: ")
     (let (char string)
-      (while (setq char (read-char nil nil ace-pinyin--jump-word-timeout))
+      (while (and (setq char (read-char nil nil ace-pinyin--jump-word-timeout))
+                  (not (char-equal char ?)))
         (setq string (concat string (char-to-string char)))
         (message (concat "Query word: " string)))
       (if string


### PR DESCRIPTION
Instead of wait for ace-pinyin--jump-word-timeout, let's finish typing with ^M.