### PR TITLE
Fix deprecated params passed to define-minor mode

### DIFF
--- a/ace-pinyin.el
+++ b/ace-pinyin.el
@@ -511,8 +511,9 @@ Without PREFIX, search both Chinese and English."
 ;;;###autoload
 (define-minor-mode ace-pinyin-mode
   "Toggle `ace-pinyin-mode'."
-  nil
-  " AcePY"
+  :init-value nil
+  :lighter " AcePY"
+  :global nil
   :group ace-pinyin
   (if ace-pinyin-mode
       (if ace-pinyin-use-avy


### PR DESCRIPTION
In Emacs 28, there was always warning massages on startup as below:
```
ace-pinyin.el: Warning: Use keywords rather than deprecated positional arguments to `define-minor-mode'
```